### PR TITLE
Use headObject to get ContentLength -  fixes #1264

### DIFF
--- a/src/repo/storageRepo/getAttachment/s3.ts
+++ b/src/repo/storageRepo/getAttachment/s3.ts
@@ -7,12 +7,15 @@ export default (config: FacadeConfig): Signature => {
   return async ({ contentType, hash, lrs_id }) => {
     const dir = getAttachmentDir({ subFolder: config.subFolder, lrs_id });
     const filePath = getAttachmentPath({ dir, hash, contentType });
-    const s3ObjectRequest = config.client.getObject({
+    const s3Params = {
       Bucket: config.bucketName,
       Key: filePath,
-    });
-    const s3Object = await s3ObjectRequest.promise();
-    const contentLength = s3Object.ContentLength;
+    };
+    const s3headObjectRequest = config.client.headObject(s3Params);
+    const s3ObjectRequest = config.client.getObject(s3Params);
+
+    const s3Head = await s3headObjectRequest.promise();
+    const contentLength = s3Head.ContentLength;
     const stream = s3ObjectRequest.createReadStream();
     return { stream, contentLength };
   };


### PR DESCRIPTION
The issue in #1264 is that getObject is being resolved in order to get the ContentLength.  This means that the call to createReadStream() is made to an already ended stream causing sendMultipartResult.ts to hang with a non resolving promise 